### PR TITLE
Fix the version of the python foundation package

### DIFF
--- a/api/attributes/default.rb
+++ b/api/attributes/default.rb
@@ -1,3 +1,5 @@
 default['celery']['config'] = '/etc/default/celeryd'
 default['app']['revision'] = 'master'
 default['db']['conn_max_age'] = 60
+default['python']['setuptools_version'] = '41.2.0'
+default['python']['virtualenv_version'] = '20.15.1'


### PR DESCRIPTION
本番サーバーでsetuptoolsのインストールに失敗する要因を見てみたところ、要因がPython2.7で対応していないバージョンをインストールしようとしていることのように見えました。
そこで、[python cookbook](https://supermarket.chef.io/cookbooks/python)のattributeで、setuptoolsとvirtualenvをPython2.7でサポートしている上限で固定してみようと思います。