### PR TITLE
add openai credential

### DIFF
--- a/retrip/templates/default/settings_base_credential.py.erb
+++ b/retrip/templates/default/settings_base_credential.py.erb
@@ -145,3 +145,6 @@ VALUECOMMERCE_ACCESS_KEY = '<%= node[:app][:valuecommerce_access_key] %>'
 
 # RAKUTEN
 RAKUTEN_BASIC_PASS = '<%= node[:app][:rakuten_basic_pass] %>'
+
+# OPENAI
+OPENAI_API_KEY = '<%= node[:app][:openai_api_key] %>'


### PR DESCRIPTION
## 目的
OpenAI API keyを環境変数に設定する(本番用)

## 内容
- https://github.com/trippiece/django-retrip/pull/5752 で利用するapi key
- Notionではhttps://github.com/amrael/opsworks_django_app のリポジトリが記載されているが、OpsWorksの設定を見るとこちらのリポジトリに変更されているようだった


## 参考
- https://www.notion.so/trippiece/credentials-3505b9c01a2c4cbfaf534dfa58dfd0a9#a7cee286bbe04e72b591627fd397b364
- https://us-east-1.console.aws.amazon.com/opsworks/home?region=ap-northeast-1#/stack/f724afad-e522-4c54-8606-7701f1f832e4/show